### PR TITLE
Add --output=ids flag to chalk list and chalk ready

### DIFF
--- a/scripts/chalk
+++ b/scripts/chalk
@@ -304,7 +304,7 @@ cmd_show() {
 
 cmd_list() {
     local filter_status="" filter_type="" filter_priority="" filter_parent="" include_closed=false
-    local limit=50
+    local limit=50 output=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -314,11 +314,17 @@ cmd_list() {
             --parent=*)   filter_parent="${1#*=}" ;;
             --closed)     include_closed=true ;;
             --limit=*)    limit="${1#*=}" ;;
-            --*)          echo "ERROR: unknown option '$1'. Valid options: --status= --type= --priority= --parent= --closed --limit= Example: chalk list --status=open --type=bug" >&2; return 1 ;;
+            --output=*)   output="${1#*=}" ;;
+            --*)          echo "ERROR: unknown option '$1'. Valid options: --status= --type= --priority= --parent= --closed --limit= --output= Example: chalk list --status=open --type=bug" >&2; return 1 ;;
             *)            echo "ERROR: unexpected argument '$1'" >&2; return 1 ;;
         esac
         shift
     done
+
+    if [[ -n "$output" && "$output" != "ids" ]]; then
+        echo "ERROR: invalid --output value '$output'. Valid values: ids" >&2
+        return 1
+    fi
 
     [[ -d "$TASKS_DIR" ]] || { echo "No tasks directory found at $TASKS_DIR"; return 0; }
 
@@ -356,7 +362,7 @@ cmd_list() {
 
     local total=${#matched[@]}
     if [[ $total -eq 0 ]]; then
-        echo "no tasks match the specified filters"
+        [[ "$output" != "ids" ]] && echo "no tasks match the specified filters"
         return 0
     fi
 
@@ -366,15 +372,22 @@ cmd_list() {
         display_count=$limit
     fi
 
-    print_header
-    local i=0
-    while [[ $i -lt $display_count ]]; do
-        print_task_row "${matched[$i]}"
-        i=$((i + 1))
-    done
-
-    if [[ $limit -gt 0 && $total -gt $limit ]]; then
-        echo "--- showing $limit of $total tasks. Use --status= --type= --priority= --parent= to filter. ---"
+    if [[ "$output" == "ids" ]]; then
+        local i=0
+        while [[ $i -lt $display_count ]]; do
+            basename "${matched[$i]}" .md
+            i=$((i + 1))
+        done
+    else
+        print_header
+        local i=0
+        while [[ $i -lt $display_count ]]; do
+            print_task_row "${matched[$i]}"
+            i=$((i + 1))
+        done
+        if [[ $limit -gt 0 && $total -gt $limit ]]; then
+            echo "--- showing $limit of $total tasks. Use --status= --type= --priority= --parent= to filter. ---"
+        fi
     fi
 }
 
@@ -552,16 +565,22 @@ cmd_close() {
 }
 
 cmd_ready() {
-    local filter_parent=""
+    local filter_parent="" output=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --parent=*) filter_parent="${1#*=}" ;;
-            --*)        echo "ERROR: unknown option '$1'. Valid options: --parent=" >&2; return 1 ;;
-            *)          echo "ERROR: unexpected argument '$1'" >&2; return 1 ;;
+            --parent=*)  filter_parent="${1#*=}" ;;
+            --output=*)  output="${1#*=}" ;;
+            --*)         echo "ERROR: unknown option '$1'. Valid options: --parent= --output=" >&2; return 1 ;;
+            *)           echo "ERROR: unexpected argument '$1'" >&2; return 1 ;;
         esac
         shift
     done
+
+    if [[ -n "$output" && "$output" != "ids" ]]; then
+        echo "ERROR: invalid --output value '$output'. Valid values: ids" >&2
+        return 1
+    fi
 
     [[ -d "$TASKS_DIR" ]] || { echo "no tasks directory found at $TASKS_DIR"; return 0; }
 
@@ -581,7 +600,7 @@ cmd_ready() {
     done < <(find "$TASKS_DIR" -maxdepth 1 -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null)
 
     if [[ ${#pairs[@]} -eq 0 ]]; then
-        echo "no open tasks"
+        [[ "$output" != "ids" ]] && echo "no open tasks"
         return 0
     fi
 
@@ -589,11 +608,18 @@ cmd_ready() {
     local -a sorted
     IFS=$'\n' read -r -d '' -a sorted < <(printf '%s\n' "${pairs[@]}" | sort -t: -k1 -n && printf '\0') || true
 
-    print_header
-    for pair in "${sorted[@]}"; do
-        local file="${pair#*:}"
-        print_task_row "$file"
-    done
+    if [[ "$output" == "ids" ]]; then
+        for pair in "${sorted[@]}"; do
+            local file="${pair#*:}"
+            basename "$file" .md
+        done
+    else
+        print_header
+        for pair in "${sorted[@]}"; do
+            local file="${pair#*:}"
+            print_task_row "$file"
+        done
+    fi
 }
 
 cmd_ghi() {
@@ -932,6 +958,7 @@ COMMANDS
     --parent=id               Filter by parent task ID
     --closed                  Include closed tasks (from .chalk/tasks/closed/)
     --limit=N                 Max rows to show (default: 50; use 0 for unlimited)
+    --output=ids              Emit one task ID per line (machine-readable)
 
   update <id>                 Update task fields
     --status=STATUS           open|in_progress|blocked|deferred
@@ -946,6 +973,7 @@ COMMANDS
 
   ready                       Show open tasks sorted by priority
     --parent=id               Filter by parent task ID
+    --output=ids              Emit one task ID per line (machine-readable)
 
   ghi clone                   Clone open GitHub issues as local tasks
     --limit=N                 Max issues to fetch (default: 500)
@@ -968,7 +996,9 @@ EXAMPLES
   chalk update task_ed8f --blocked_by=bug_a3f2
   chalk close task_ed8f
   chalk list --status=open --type=bug
+  chalk list --status=blocked --output=ids | xargs -I{} chalk close {}
   chalk ready
+  chalk ready --output=ids
 HELP
 }
 


### PR DESCRIPTION
Emits one task ID per line for machine-readable output, enabling
shell pipelines like: chalk list --status=blocked --output=ids | xargs -I{} chalk close {}

https://claude.ai/code/session_01SN8iudiDeLQJBdwK9w4X69